### PR TITLE
remove the .git repository as part of installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Go to the directory where you have your Hugo site and run:
 $ mkdir themes
 $ cd themes
 $ git clone https://github.com/kishaningithub/hugo-creative-portfolio-theme.git
+$ rm -rf hugo-creative-portfolio-theme/.git
 ```
 
 For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.


### PR DESCRIPTION
otherwise deployment on Linux will fail, as it interferes with this .git directory. In any case heving it is annoying since the reference to is keeps changing. Since we don't care about the history, just the files of the theme, it makes sense to remove the .git dir completely.

Having done this fixed my deployment issues on Netlify.