### PR TITLE
Fixed sidebar padding in custom style files

### DIFF
--- a/static/css/style.blue.css
+++ b/static/css/style.blue.css
@@ -324,12 +324,12 @@ SIDEBAR + RIGHT COLUMN
     position: fixed;
     width: inherit;
     z-index: 0;
-    padding: 0 1em 0 0.2em;
+    padding: 0 1.7em 0 0em;
 }
 @media screen and (min-width: 992px) {
   .sidebar-content {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 18px;
   }
 }
 .sidebar-heading {

--- a/static/css/style.green.css
+++ b/static/css/style.green.css
@@ -324,12 +324,12 @@ SIDEBAR + RIGHT COLUMN
     position: fixed;
     width: inherit;
     z-index: 0;
-    padding: 0 1em 0 0.2em;
+    padding: 0 1.7em 0 0em;
 }
 @media screen and (min-width: 992px) {
   .sidebar-content {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 18px;
   }
 }
 .sidebar-heading {

--- a/static/css/style.pink.css
+++ b/static/css/style.pink.css
@@ -324,12 +324,12 @@ SIDEBAR + RIGHT COLUMN
     position: fixed;
     width: inherit;
     z-index: 0;
-    padding: 0 1em 0 0.2em;
+    padding: 0 1.7em 0 0em;
 }
 @media screen and (min-width: 992px) {
   .sidebar-content {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 18px;
   }
 }
 .sidebar-heading {

--- a/static/css/style.red.css
+++ b/static/css/style.red.css
@@ -324,12 +324,12 @@ SIDEBAR + RIGHT COLUMN
     position: fixed;
     width: inherit;
     z-index: 0;
-    padding: 0 1em 0 0.2em;
+    padding: 0 1.7em 0 0em;
 }
 @media screen and (min-width: 992px) {
   .sidebar-content {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 18px;
   }
 }
 .sidebar-heading {

--- a/static/css/style.sea.css
+++ b/static/css/style.sea.css
@@ -324,12 +324,12 @@ SIDEBAR + RIGHT COLUMN
     position: fixed;
     width: inherit;
     z-index: 0;
-    padding: 0 1em 0 0.2em;
+    padding: 0 1.7em 0 0em;
 }
 @media screen and (min-width: 992px) {
   .sidebar-content {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 18px;
   }
 }
 .sidebar-heading {

--- a/static/css/style.violet.css
+++ b/static/css/style.violet.css
@@ -324,12 +324,12 @@ SIDEBAR + RIGHT COLUMN
     position: fixed;
     width: inherit;
     z-index: 0;
-    padding: 0 1em 0 0.2em;
+    padding: 0 1.7em 0 0em;
 }
 @media screen and (min-width: 992px) {
   .sidebar-content {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 0px;
+    padding-right: 18px;
   }
 }
 .sidebar-heading {


### PR DESCRIPTION
Sidebar padding works as expected when using default style: 
![default](https://user-images.githubusercontent.com/15819543/50692716-11d51880-1035-11e9-8981-3fe1bb9e16c9.png)

but for custom styles it's not:
![other](https://user-images.githubusercontent.com/15819543/50692737-21546180-1035-11e9-93a6-e49c6fed2961.png)

After the fix:
![after](https://user-images.githubusercontent.com/15819543/50692761-34673180-1035-11e9-8ffa-fee66644854e.png)

