### PR TITLE
Add Stackbit Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ rm -rf hugo-creative-portfolio-theme/.git
 
 For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
 
+## Create with Stackbit
+
+This theme contains a `stackbit.yaml` file and can be used with Stackbit to instantly deploy to Netlify with optional headless CMS (Contentful, DatoCMS, Forestry, NetlifyCMS, etc.).
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/kishaningithub/hugo-creative-portfolio-theme)
+
 ## Configuration
 
 After installing the Creative portfolio theme successfully, i recommend you to take a look at the [exampleSite](https://github.com/kishaningithub/hugo-creative-portfolio-theme/tree/master/exampleSite) directory. You will find a working Hugo site configured with the Creative portfolio theme that you can use as a starting point for your site.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,7 @@
 baseurl = "https://example.org/"
 title = "Creative portfolio"
 theme = "hugo-creative-portfolio-theme"
+themesDir = "../.."
 languageCode = "en-us"
 # Enable comments by entering your Disqus shortname
 disqusShortname = ""

--- a/exampleSite/content/about/_index.md
+++ b/exampleSite/content/about/_index.md
@@ -1,7 +1,7 @@
----
-date: "2016-11-05T21:05:33+05:30"
-title: "About me"
----
++++
+date = "2016-11-05T21:05:33+05:30"
+title = "About me"
++++
 
 An sincerity so extremity he additions. Her yet **there truth merit**. Mrs all projecting favourable now unpleasing. Son law garden chatty temper. Oh children provided to mr elegance marriage strongly. Off can admiration prosperous now devonshire diminution law.
 

--- a/exampleSite/content/about/_index.md
+++ b/exampleSite/content/about/_index.md
@@ -1,7 +1,7 @@
-+++
-date = "2016-11-05T21:05:33+05:30"
-title = "About me"
-+++
+---
+date: "2016-11-05T21:05:33+05:30"
+title: "About me"
+---
 
 An sincerity so extremity he additions. Her yet **there truth merit**. Mrs all projecting favourable now unpleasing. Son law garden chatty temper. Oh children provided to mr elegance marriage strongly. Off can admiration prosperous now devonshire diminution law.
 
@@ -13,8 +13,8 @@ The Big Oxmox advised her not to do so, because there were thousands of bad Comm
 
 #### Education
 
-* Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
-* Aliquam tincidunt mauris eu risus.
+- Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+- Aliquam tincidunt mauris eu risus.
 
 When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet Village and the subline of her own road, the Line Lane. Pityful a rethoric question ran over her cheek, then
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,9 +4,12 @@
   <div class="row">
     <div class="col-lg-8">
       <div class="content-column-content">
-         <h1>{{ .Title }}</h1>
-         {{ .Content }}
-         {{ template "_internal/disqus.html" . }}
+        <h1>{{ .Title }}</h1>
+        <div class="margin-bottom">
+          <img src="{{ .Params.image | relURL }}" />
+        </div>
+        {{ .Content }}
+        {{ template "_internal/disqus.html" . }}
       </div>
     </div>
   </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,3 @@
-<head> 
-    {{ range .Site.Params.navlinks }}
-    {{ if .home }}
-    <meta http-equiv="refresh" content="0; URL={{ .url | absURL }}" />
-    {{ end }}
-    {{ end }}
-  </head>
+{{ define "main" }}
+{{ partial "portfolio.html" . }}
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  publish = "exampleSite/public"
+  command = "cd exampleSite && hugo --gc --themesDir ../.."
+
+[build.environment]
+  HUGO_VERSION = "0.51"
+  HUGO_THEME = "repo"
+  HUGO_BASEURL = "/"

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -2,7 +2,7 @@ stackbitVersion: ~0.2.0
 ssgName: custom
 publishDir: exampleSite/public
 buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
-uploadDir: images
+uploadDir: img
 staticDir: exampleSite/static
 pagesDir: exampleSite/content
 dataDir: exampleSite

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,142 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+publishDir: exampleSite/public
+buildCommand: cd exampleSite && hugo --gc --baseURL "/" --themesDir ../.. && cd ..
+uploadDir: images
+staticDir: exampleSite/static
+pagesDir: exampleSite/content
+dataDir: exampleSite
+models:
+  config:
+    type: data
+    label: Config
+    file: config.toml
+    fields:
+      - type: string
+        name: title
+        label: Title
+        required: true
+      - type: string
+        name: baseurl
+        label: Base URL
+        description: Hostname (and path) to the root
+      - type: string
+        name: theme
+        label: Theme Name
+      - type: string
+        name: languageCode
+        label: Language Code "en"
+      - type: string
+        name: themesDir
+        label: Themes Folder Path
+      - type: string
+        name: googleAnalytics
+        label: Google Analytics ID
+      - type: string
+        name: disqusShortname
+        label: Disqus Shortname
+      - type: object
+        name: params
+        label: Params
+        description: Site parameters
+        fields:
+          - type: enum
+            name: style
+            label: Theme Style
+            options: ['default', 'blue', 'green', 'pink', 'red', 'sea', 'violet']
+          - type: string
+            name: description
+            label: Description
+          - type: string
+            name: copyright
+            label: Copyright
+          - type: list
+            name: sidebarAbout
+            items:
+              type: string
+          - type: string
+            name: email
+            label: Email
+          - type: list
+            name: navlinks
+            fields:
+              - type: object
+                name: link
+                fields:
+                  - type: string
+                    name: name
+                    label: Name
+                  - type: string
+                    name: url
+                    label: URL
+                  - type: boolean
+                    name: home
+                    label: Is This The Homepage Link?
+          - type: object
+            name: social
+            fields:
+              - type: string
+                name: facebook
+              - type: string
+                name: googleplus
+              - type: string
+                name: email
+              - type: string
+                name: twitter
+              - type: string
+                name: linkedin
+              - type: string
+                name: stackoverflow
+              - type: string
+                name: instagram
+              - type: string
+                name: github
+              - type: string
+                name: youtube
+              - type: string
+                name: whatsapp
+  about:
+    type: page
+    label: About
+    folder: about
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: date
+        name: date
+        label: Date
+  contact:
+    type: page
+    label: Contact
+    folder: contact
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: date
+        name: date
+        label: Date
+  portfolio:
+    type: page
+    label: Portfolio
+    folder: portfolio
+    fields:
+      - type: string
+        name: title
+        label: Title
+      - type: date
+        name: date
+        label: Date
+      - type: boolean
+        name: showonlyimage
+        label: Show Only Image?
+      - type: boolean
+        name: draft
+        label: Draft
+      - type: image
+        name: image
+        label: image
+      - type: number
+        name: weight
+        label: Weight

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -59,19 +59,19 @@ models:
             label: Email
           - type: list
             name: navlinks
-            fields:
-              - type: object
-                name: link
-                fields:
-                  - type: string
-                    name: name
-                    label: Name
-                  - type: string
-                    name: url
-                    label: URL
-                  - type: boolean
-                    name: home
-                    label: Is This The Homepage Link?
+            items:
+              type: object
+              labelField: name
+              fields:
+                - type: string
+                  name: name
+                  label: Name
+                - type: string
+                  name: url
+                  label: URL
+                - type: boolean
+                  name: home
+                  label: Is This The Homepage Link?
           - type: object
             name: social
             fields:


### PR DESCRIPTION
Hey mate really like your themes. I've added Stackbit to this theme which lets people deploy it to Netlify and connect a headless CMS in 1 click. You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/hugo-creative-portfolio-theme

The main addition is the `stackbit.yaml` file which is basically the Stackbit integration.
I also added a netlify.toml which will assist with Netlify deploys.

I made a couple of bug fixes as well. Images are now displayed on Portfolio pages and the homepage no longer works as a redirect because a) I think this is a real problem for SEO and b) the headless CMS freak out when they get this redirect and dont work.
