### PR TITLE
Fix sidebar credit in case of missing copyright parameter

### DIFF
--- a/layouts/partials/attribution.html
+++ b/layouts/partials/attribution.html
@@ -1,3 +1,3 @@
-| Template by <a href="https://bootstrapious.com/free-templates" class="external">Bootstrapious.com</a>
+Template by <a href="https://bootstrapious.com/free-templates" class="external">Bootstrapious.com</a>
 <!-- Not removing this link is part of the licence conditions of the template. Thanks for understanding :) -->
 &amp; ported to Hugo by <a href="https://github.com/kishaningithub">Kishan B</a>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -14,7 +14,7 @@
     <div class="copyright">
       <p class="credit">
         {{ with .Site.Params.copyright }}
-          {{ . | safeHTML }}
+          {{ . | safeHTML }} |
         {{ end }}
         {{ partial "attribution.html" . }}
       </p>


### PR DESCRIPTION
Without the `copyright` parameter the credit was `| Template by ...`. Now
it is `Template by ...` instead.