### PR TITLE
layouts/partials: Remove robots meta tags of head

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,8 +3,6 @@
 {{ with .Title }}<title>{{ . }}</title>{{ end }}
 {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="all,follow">
-<meta name="googlebot" content="index,follow,snippet,archive">
 <link rel="stylesheet" href="{{ "css/bootstrap.min.css" | absURL }}">
 <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:400,300,700,400italic">
 <link rel="stylesheet" href="{{ "css/font-awesome.min.css" | absURL }}">


### PR DESCRIPTION
Remove the robots meta tags of the head template because they are
redundant and it's what it's applied by default.

See https://developers.google.com/search/reference/robots_meta_tag