### PR TITLE
Fix site title

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,6 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-{{ with .Title }}<title>{{ . }}</title>{{ end }}
+{{ with .Site.Title }}<title>{{ . }}</title>{{ end }}
 {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="all,follow">


### PR DESCRIPTION
By using `.Site.Title` the theme will honor the property `title` from `config.toml`.