### PR TITLE
Fix support for GA G4

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,4 +29,4 @@
 {{ with .OutputFormats.Get "RSS" }}
   {{ printf `<link href="%s" rel="%s" type="%s" title="%s" />` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }}
 {{ end }}
-{{ template "_internal/google_analytics_async.html" . }}
+{{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
Update head partial layout
- Changes Hugo internal template to give support for both UA and G4 (fixes #87)

Considering the alert from Google Analytics and this comment:
>  on issue https://github.com/kishaningithub/hugo-creative-portfolio-theme/issues/87#issuecomment-1113342185
