### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/social_buttons_in_contact.html
+++ b/layouts/partials/social_buttons_in_contact.html
@@ -1,21 +1,21 @@
 <p class="social social--big">
   {{ with .Site.Params.social.facebook }}
-  <a href="{{ . }}" class="facebook" title="Facebook">
+  <a href="{{ . }}" class="facebook" title="Facebook" rel="me">
     <i class="fa fa-facebook"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.googleplus }}
-  <a href="{{ . }}" class="gplus" title="Google Plus">
+  <a href="{{ . }}" class="gplus" title="Google Plus" rel="me">
     <i class="fa fa-google-plus"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.twitter }}
-  <a href="{{ . }}" class="twitter" title="Twitter">
+  <a href="{{ . }}" class="twitter" title="Twitter" rel="me">
     <i class="fa fa-twitter"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.instagram }}
-  <a href="{{ . }}" title="" class="instagram" title="Instagram">
+  <a href="{{ . }}" title="" class="instagram" title="Instagram" rel="me">
     <i class="fa fa-instagram"></i>
   </a>
   {{end}}
@@ -25,27 +25,27 @@
   </a>
   {{end}}
   {{ with .Site.Params.social.linkedin }}
-  <a href="{{ . }}" title="LinkedIn">
+  <a href="{{ . }}" title="LinkedIn" rel="me">
     <i class="fa fa-linkedin"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.stackoverflow }}
-  <a href="{{ . }}" title="Stack Overflow">
+  <a href="{{ . }}" title="Stack Overflow" rel="me">
     <i class="fa fa-stack-overflow"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.github }}
-  <a href="{{ . }}" title="GitHub">
+  <a href="{{ . }}" title="GitHub" rel="me">
     <i class="fa fa-github"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.gitlab }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="GitLab">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="GitLab" rel="me">
     <i class="fa fa-gitlab"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.youtube }}
-  <a href="{{ . }}" title="YouTube">
+  <a href="{{ . }}" title="YouTube" rel="me">
     <i class="fa fa-youtube"></i>
   </a>
   {{end}}

--- a/layouts/partials/social_buttons_in_sidebar.html
+++ b/layouts/partials/social_buttons_in_sidebar.html
@@ -1,21 +1,21 @@
 <p class="social">
   {{ with .Site.Params.social.facebook }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external facebook" title="Facebook">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external facebook" title="Facebook" rel="me">
     <i class="fa fa-facebook"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.googleplus }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external gplus" title="Google Plus">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external gplus" title="Google Plus" rel="me">
     <i class="fa fa-google-plus"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.twitter }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external twitter" title="Twitter">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external twitter" title="Twitter" rel="me">
     <i class="fa fa-twitter"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.instagram }}
-  <a href="{{ . }}" title="" class="external instagram" title="Instagram">
+  <a href="{{ . }}" title="" class="external instagram" title="Instagram" rel="me">
     <i class="fa fa-instagram"></i>
   </a>
   {{end}}
@@ -25,27 +25,27 @@
   </a>
   {{end}}
   {{ with .Site.Params.social.linkedin }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="LinkedIn">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="LinkedIn" rel="me">
     <i class="fa fa-linkedin"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.stackoverflow }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="Stack Overflow">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="Stack Overflow" rel="me">
     <i class="fa fa-stack-overflow"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.github }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="GitHub">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="GitHub" rel="me">
     <i class="fa fa-github"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.gitlab }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="GitLab">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="GitLab" rel="me">
     <i class="fa fa-gitlab"></i>
   </a>
   {{end}}
   {{ with .Site.Params.social.youtube }}
-  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="YouTube">
+  <a href="{{ . }}" data-animate-hover="pulse" class="external" title="YouTube" rel="me">
     <i class="fa fa-youtube"></i>
   </a>
   {{end}}


### PR DESCRIPTION
[rel="me"] is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.

[rel="me"]: https://indieweb.org/rel-me