### PR TITLE
Make theme work as hugo module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 install:
   - mkdir tools
-  - wget -q "https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.tar.gz" -O "tools/hugo.tar.gz"
+  - wget -q "https://github.com/gohugoio/hugo/releases/download/v0.115.4/hugo_extended_0.115.4_Linux-64bit.tar.gz" -O "tools/hugo.tar.gz"
   - tar -xzf tools/hugo.tar.gz -C tools
   
 script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Creative portfolio theme for hugo
 
-[![Build Status](https://travis-ci.org/kishaningithub/hugo-creative-portfolio-theme.svg?branch=master)](https://travis-ci.org/kishaningithub/hugo-creative-portfolio-theme)
 [![Join the chat at https://gitter.im/hugo-creative-portfolio-theme/Lobby](https://badges.gitter.im/hugo-creative-portfolio-theme/Lobby.svg)](https://gitter.im/hugo-creative-portfolio-theme/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Buy me a coffee](https://img.shields.io/badge/☕-Buy%20me%20a%20coffee-blue.svg)](https://www.paypal.me/kishansh/5)
 
@@ -12,6 +11,8 @@ This Hugo theme was ported from [Bootstrapious](https://bootstrapious.com/p/crea
 
 ## Installation
 
+### Use theme component locally as git clone
+
 Go to the directory where you have your Hugo site and run:
 
 ```bash
@@ -21,7 +22,26 @@ git clone https://github.com/kishaningithub/hugo-creative-portfolio-theme.git
 rm -rf hugo-creative-portfolio-theme/.git
 ```
 
-For more information read the official [setup guide](https://gohugo.io/overview/installing/) of Hugo.
+For more information read the official documentation on [theme components](https://gohugo.io/hugo-modules/theme-components/).
+
+### Use theme as hugo module
+
+In the root directory of your project, initialise your project as hugo module and add the `hugo-creative-portfolio-theme` theme as dependency:
+
+```bash
+hugo mod init github.com/me/my-new-site
+hugo mod get github.com/kishaningithub/hugo-creative-portfolio-theme
+```
+
+In your `hugo.toml` / `config.toml`, add these lines to add the theme:
+
+```bash
+[module]
+[[module.imports]]
+path = "github.com/google/docsy/dependencies"
+```
+
+For more information read the official documentation on [hugo modules](https://gohugo.io/hugo-modules/use-modules/) of Hugo.
 
 ## Configuration
 
@@ -101,4 +121,4 @@ This port is released under the MIT License. Check the [original theme license](
 
 ## Thanks
 
-Thanks to [Steve Francia](https://github.com/spf13) for creating Hugo and the awesome community around the project. And also thanks to [Bootstrapious](http://bootstrapious.com/) for creating this awesome theme.
+Thanks to [Steve Francia](https://github.com/spf13) for creating Hugo and the awesome community around the project. And also thanks to [Bootstrapious](https://bootstrapious.com/) for creating this awesome theme.

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+.hugo_build.lock
+themes/
+public/

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,11 +1,18 @@
 baseurl = "https://example.org/"
 title = "Creative portfolio"
-theme = "hugo-creative-portfolio-theme"
 languageCode = "en-us"
 # Enable comments by entering your Disqus shortname
 disqusShortname = ""
 # Enable Google Analytics by entering your tracking code
 googleAnalytics = ""
+
+# Run theme as local git clone
+theme = "github.com/kishaningithub/hugo-creative-portfolio-theme"
+# Or, if you want to run theme as hugo module
+# [module]
+#   [[module.imports]]
+#     path = "github.com/google/docsy"
+
 
 [params]
   # Style options: default (pink), blue, green, pink, red, sea, violet

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kishaningithub/hugo-creative-portfolio-theme
 
-go 1.20
+go 1.21

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kishaningithub/hugo-creative-portfolio-theme
+
+go 1.20


### PR DESCRIPTION
This PR makes the theme work as hugo module, too. Documentation for this way of installation is provided in `README.md`.